### PR TITLE
fix: reduce absurdly large password hash size

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   pre:
     - curl https://raw.githubusercontent.com/creationix/nvm/v0.23.3/install.sh | bash
   node:
-    version: 4.0.0
+    version: 6.9.1
 test:
   override:
     - npm run lint


### PR DESCRIPTION
Previously, the password hashes generated would be 584 bytes (512 + 64 +
8) which is far larger than necessary for security. As a result, they
would unnecessarily bloat the ledger database.

Cause of the bug was a misinterpretation on my part of the `crypto.pbkdf2`
function. I thought it expected the key length in bits, but it expects
it in bytes. (In the example a `keylen` of 512 is used with SHA-512, so I
think the documentation writer made the same error.)

Since a smaller output size also causes a speed-up, I'm increasing the
default iteration count to compensate.

In this commit, I'm choosing sane values for salt and hash size that lead
to an overall password hash size of 40 bytes (instead of 548).

Also note that since the salt size, hash size and iteration count are
parsed from existing password hash database entries, this change is
fully backward-compatible.