### PR TITLE
Replaces the schema validator tv4 with ajv

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -9,8 +9,7 @@ const InvalidBodyError = require('../errors/invalid-body-error')
 const InvalidUriParameterError =
   require('../errors/invalid-uri-parameter-error')
 
-const tv4 = require('tv4')
-const formats = require('tv4-formats')
+const Ajv = require('ajv')
 
 const BASE_DIR = path.join(__dirname, '/../schemas')
 
@@ -33,8 +32,7 @@ const BASE_DIR = path.join(__dirname, '/../schemas')
  */
 class Validator {
   constructor () {
-    this.tv4 = tv4.freshApi()
-    this.tv4.addFormat(formats)
+    this.ajv = new Ajv()
     this.loadedDirectories = new Set()
   }
 
@@ -64,7 +62,7 @@ class Validator {
       .forEach((fileName) => {
         try {
           let schemaJson = fs.readFileSync(path.join(dirPath, fileName), 'utf8')
-          this.tv4.addSchema(fileName, JSON.parse(schemaJson))
+          this.ajv.addSchema(JSON.parse(schemaJson), fileName)
         } catch (e) {
           throw new ServerError('Failed to parse schema: ' + fileName)
         }
@@ -78,9 +76,14 @@ class Validator {
    */
   create (schema) {
     return (data) => {
-      const result = this.tv4.validateMultiple(data, schema + '.json')
-      result.schema = schema
-      return result
+      const isValid = this.ajv.validate(schema + '.json', data)
+
+      // Returning it in the same format as tv4.validateMultiple would do
+      return {
+        valid: isValid,
+        schema: schema,
+        errors: (isValid) ? undefined : this.ajv.errors
+      }
     }
   }
 
@@ -94,10 +97,10 @@ class Validator {
    * @returns {void}
    */
   validateUriParameter (paramId, paramValue, schema) {
-    const validationResult = this.tv4.validateMultiple(paramValue, schema + '.json')
-    if (!validationResult.valid) {
+    const isValid = this.ajv.validate(schema + '.json', paramValue)
+    if (!isValid) {
       throw new InvalidUriParameterError(paramId + ' is not a valid ' + schema,
-        validationResult.errors)
+        this.ajv.errors)
     }
   }
 
@@ -117,13 +120,11 @@ class Validator {
     const json = yield parse(ctx)
 
     if (schema) {
-      const validationResult = this.tv4.validateMultiple(json, schema + '.json')
-      if (!validationResult.valid) {
+      const isValid = this.ajv.validate(schema + '.json', json)
+      if (!isValid) {
         throw new InvalidBodyError('JSON request body is not a valid ' + schema,
-          validationResult.errors)
+          this.ajv.errors)
       }
-      // TODO Might be good to do this for safety:
-      // return validationResult.cleanInstance
     }
 
     return json

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/interledgerjs/five-bells-shared",
   "dependencies": {
+    "ajv": "^4.9.0",
     "canonical-json": "0.0.4",
     "co": "^4.1.0",
     "co-body": "^4.2.0",
@@ -42,8 +43,6 @@
     "path-to-regexp": "^1.2.0",
     "retry-as-promised": "^2.0.1",
     "through2": "^2.0.1",
-    "tv4": "^1.2.7",
-    "tv4-formats": "^2.2.1",
     "tweetnacl": "^0.14.3"
   },
   "peerDependencies": {

--- a/schemas/PublicKeyEC.json
+++ b/schemas/PublicKeyEC.json
@@ -24,8 +24,8 @@
     "y": {
       "description": "EC curve point Y.",
       "$ref": "Base64URL.json"
-    },
-    "required": ["type", "curve", "x", "y"],
-    "additionalProperties": false
-  }
+    }
+  },
+  "required": ["type", "curve", "x", "y"],
+  "additionalProperties": false
 }

--- a/schemas/PublicKeyRSA.json
+++ b/schemas/PublicKeyRSA.json
@@ -16,8 +16,8 @@
     "e": {
       "description": "RSA exponent.",
       "$ref": "Base64URL.json"
-    },
-    "required": ["type", "n", "e"],
-    "additionalProperties": false
-  }
+    }
+  },
+  "required": ["type", "n", "e"],
+  "additionalProperties": false
 }


### PR DESCRIPTION
The current schema validator tv4 is replaced with ajv. The new validator is faster and checks the schema soundness more thoroughly.

In addition, this PR fixes two broken schemas. The field "required" was within the array "properties". Therefore, the schema validator did not check that the field specified by required does exist.