### PR TITLE
fix: update vulnerable dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -599,12 +599,6 @@
         "iconv-lite": "0.4.19"
       }
     },
-    "entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-      "dev": true
-    },
     "es5-ext": {
       "version": "0.10.35",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
@@ -1431,7 +1425,9 @@
       "optional": true
     },
     "jsdoc": {
-      "version": "git+https://github.com/jsdoc3/jsdoc.git#b21427343c7294bbf1f14c718a390f3e955e37cb",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
+      "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
       "dev": true,
       "requires": {
         "babylon": "7.0.0-beta.19",
@@ -1440,9 +1436,7 @@
         "escape-string-regexp": "1.0.5",
         "js2xmlparser": "3.0.0",
         "klaw": "2.0.0",
-        "markdown-it": "8.3.2",
-        "markdown-it-named-headers": "0.0.4",
-        "marked": "0.3.6",
+        "marked": "0.3.9",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -1546,15 +1540,6 @@
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
-      }
-    },
-    "linkify-it": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
-      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
-      "dev": true,
-      "requires": {
-        "uc.micro": "1.0.3"
       }
     },
     "lodash": {
@@ -1692,38 +1677,10 @@
         }
       }
     },
-    "markdown-it": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.3.2.tgz",
-      "integrity": "sha512-4J92IhJq1kGoyXddwzzfjr9cEKGexBfFsZooKYMhMLLlWa4+dlSPDUUP7y+xQOCebIj61aLmKlowg//YcdPP1w==",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "entities": "1.1.1",
-        "linkify-it": "2.0.3",
-        "mdurl": "1.0.1",
-        "uc.micro": "1.0.3"
-      }
-    },
-    "markdown-it-named-headers": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-named-headers/-/markdown-it-named-headers-0.0.4.tgz",
-      "integrity": "sha1-gu/CgyQkCmsed7mq5QF3HV81HB8=",
-      "dev": true,
-      "requires": {
-        "string": "3.3.3"
-      }
-    },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
-      "dev": true
-    },
-    "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw==",
       "dev": true
     },
     "media-typer": {
@@ -2314,12 +2271,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
-    "string": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
-      "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA=",
-      "dev": true
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2510,12 +2461,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "uc.micro": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
-      "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI=",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "five-bells-integration-test-loader": "^1.0.1",
     "interledger-jsdoc-template": "^2.0.0",
     "istanbul": "^0.4.5",
-    "jsdoc": "git+https://github.com/jsdoc3/jsdoc.git",
+    "jsdoc": "^3.5.5",
+    "marked": "^0.3.9",
     "mocha": "^3.2.0",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0"


### PR DESCRIPTION
marked@0.3.9 is added to devDependencies so that jsdoc is forced to use this version instead of an older vulnerable version of marked